### PR TITLE
fix: should not remove array item while iterating it

### DIFF
--- a/web/app/cad/scene/selectionMarker/markerBundle.ts
+++ b/web/app/cad/scene/selectionMarker/markerBundle.ts
@@ -88,11 +88,13 @@ function createMarker(findEntity, requestRender) {
   }
 
   function withdrawAllOfType(entityType) {
+    const withdrawObj = [];
     marked.forEach(obj => {
       if (obj.TYPE === entityType) {
-        doWithdraw(obj);
+        withdrawObj.push(obj);
       }
     });
+    withdrawObj.forEach(obj => doWithdraw(obj));
   }
   
   function markExclusively(entity, id, color) {
@@ -133,12 +135,14 @@ function createMarker(findEntity, requestRender) {
   }
 
   function commit() {
+    const withdrawObj = [];
     marked.forEach((obj) => {
       if (!markingSession.has(obj.id)) {
-        doWithdraw(obj);
+        withdrawObj.push(obj);
         needUpdate = true;
       }
     });
+    withdrawObj.forEach(obj => doWithdraw(obj));
     if (needUpdate) {
       onUpdate();
     }


### PR DESCRIPTION
Description:
=========================
extrude to get a model, press shift and select more than one face, then release shift and select another face, can not withdraw selected faces normally
caused by removing face from marked-obj array while iterating it


Contributor name: xia0hj
=========================


Confirm compliance with JSketcher project license. 
=========================
- [x] Pull request is made compliance with JSKetcher license  